### PR TITLE
Update mixtral.py

### DIFF
--- a/llms/mlx_lm/models/mixtral.py
+++ b/llms/mlx_lm/models/mixtral.py
@@ -127,7 +127,7 @@ class MixtralSparseMoeBlock(nn.Module):
         ]
 
     def __call__(self, x: mx.array) -> mx.array:
-        ne = self.num_experts_per_tok
+        ne = self.num_experts_per_tok - 1
         orig_shape = x.shape
         x = x.reshape(-1, x.shape[-1])
 


### PR DESCRIPTION
I try to make a mlx version of my MOE model cloudyu/Mixtral_34Bx2_MoE_60B https://huggingface.co/cloudyu/Mixtral_34Bx2_MoE_60B

But the mlx version doesn't work, I don't know the reason.

it report:
mlx-examples/llms/mlx_lm/models/mixtral.py", line 137, in call
mx.argpartition(-gates, kth=ne, axis=-1)[:, :ne]
ValueError: [argpartition] Received invalid kth 2 along axis -1 for array with shape: (1,2)

I read the code
https://github.com/ml-explore/mlx-examples/blob/main/llms/mlx_lm/models/mixtral.py

at 130 line:

it should be ne = self.num_experts_per_tok - 1 instead of ne = self.num_experts_per_tok

ne = self.num_experts_per_tok that means 1+self.num_experts_per_tok experts working.